### PR TITLE
Update to start_server() in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub fn logs() {
 ///
 pub fn start_server() {
     let paths = ["/Applications/Sonic Pi.app/server/bin/sonic-pi-server.rb",
-                 "./app/server/bin/sonic-pi-server.rb"];
+                 "./app/server/bin/sonic-pi-server.rb", "/usr/lib/sonic-pi/server/bin/sonic-pi-server.rb"];
 
     match paths.iter().find(|&&p| Path::new(p).exists()) {
         Some(p) => {


### PR DESCRIPTION
The start_server() function now also checks "/usr/lib/sonic-pi/server/bin/sonic-pi-server.rb" for the Sonic Pi server executable. This allows the function to work on Debian (and hopefully other linux distros).